### PR TITLE
Removal of the backdrop filter (CSS property) because it blurs text when the selection is small (e.g. buttons)

### DIFF
--- a/css/wizard.css
+++ b/css/wizard.css
@@ -323,7 +323,6 @@
 /* Modal overlay aanpassing - darker for better focus */
 .shepherd-modal-overlay-container {
   opacity: 0.7 !important;
-  backdrop-filter: blur(3px);
   background: rgba(0, 0, 0, 0.4) !important;
 }
 


### PR DESCRIPTION
Simply darkening what is around it is enough.

| Before | After |
| --- | --- |
| <img width="432" height="369" alt="2025-12-03_11-56" src="https://github.com/user-attachments/assets/7dd57a74-8c20-4dc7-8fa2-303d9e736af3" /> | <img width="432" height="369" alt="2025-12-03_11-57" src="https://github.com/user-attachments/assets/fb7929e8-f4ba-4879-918d-a6d1738a9806" /> |